### PR TITLE
feat: Add type definitions to defineConfig in basic-module

### DIFF
--- a/examples/basic-module/modern.config.ts
+++ b/examples/basic-module/modern.config.ts
@@ -1,6 +1,12 @@
-import { moduleTools, defineConfig } from '@modern-js/module-tools';
+import {
+  moduleTools,
+  defineConfig,
+  ModuleConfigParams,
+} from '@modern-js/module-tools';
+import type { UserConfigExport } from '@modern-js/core';
 
-export default defineConfig({
+const config: UserConfigExport<ModuleConfigParams> = {
   plugins: [moduleTools()],
   buildPreset: 'npm-library',
-});
+};
+export default defineConfig(config);

--- a/examples/basic-module/package.json
+++ b/examples/basic-module/package.json
@@ -43,7 +43,8 @@
     "rimraf": "~3.0.2",
     "lint-staged": "~13.1.0",
     "prettier": "~2.8.1",
-    "husky": "~8.0.1"
+    "husky": "~8.0.1",
+    "@modern-js/core": "^2.48.5"
   },
   "sideEffects": [],
   "publishConfig": {


### PR DESCRIPTION
This PR adds TypeScript type definitions to the defineConfig function in the basic-module, improving code quality by providing type hints for better code understanding and development. The type definitions enhance the readability and maintainability of the codebase, contributing to a more robust development process.


