### PR TITLE
chore(mf): update module-federation demo

### DIFF
--- a/examples/module-federation/app-export/host/@mf-types/remote/compiled-types/src/export-App.d.ts
+++ b/examples/module-federation/app-export/host/@mf-types/remote/compiled-types/src/export-App.d.ts
@@ -1,11 +1,13 @@
-/// <reference types="react" />
 import '@modern-js/runtime/registry/main';
 export declare const provider: () => {
-    render(info: any): Promise<void>;
-    destroy(info: {
-        dom: HTMLElement;
-    }): Promise<void>;
-    rawComponent: import("react").ComponentType<any>;
-    __BRIDGE_FN__: (_args: any) => void;
+  render(
+    info: import('@module-federation/bridge-react').RenderFnParams & {
+      [key: string]: unknown;
+    },
+  ): Promise<void>;
+  destroy(info: {
+    moduleName: string;
+    dom: HTMLElement;
+  }): void;
 };
 export default provider;

--- a/examples/module-federation/app-export/host/module-federation.config.ts
+++ b/examples/module-federation/app-export/host/module-federation.config.ts
@@ -3,7 +3,7 @@ import { createModuleFederationConfig } from '@module-federation/modern-js';
 export default createModuleFederationConfig({
   name: 'host',
   remotes: {
-    remote: 'remote@http://localhost:3051/mf-manifest.json',
+    remote: 'remote@http://localhost:3051/static/mf-manifest.json',
   },
   shared: {
     react: { singleton: true },

--- a/examples/module-federation/app-export/host/package.json
+++ b/examples/module-federation/app-export/host/package.json
@@ -24,16 +24,16 @@
     "pre-commit": "npx lint-staged"
   },
   "dependencies": {
-    "@modern-js/runtime": "2.60.1",
-    "@module-federation/bridge-react": "^0.6.6",
-    "@module-federation/modern-js": "^0.6.6",
+    "@modern-js/runtime": "2.65.3",
+    "@module-federation/bridge-react": "0.10.0",
+    "@module-federation/modern-js": "0.10.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@modern-js/app-tools": "2.60.1",
-    "@modern-js/tsconfig": "2.60.1",
+    "@modern-js/app-tools": "2.65.3",
+    "@modern-js/tsconfig": "2.65.3",
     "@types/jest": "~29.2.4",
     "@types/node": "~16.11.7",
     "@types/react": "~18.0.26",

--- a/examples/module-federation/app-export/remote/modern.config.ts
+++ b/examples/module-federation/app-export/remote/modern.config.ts
@@ -1,13 +1,21 @@
 import { appTools, defineConfig } from '@modern-js/app-tools';
 import { moduleFederationPlugin } from '@module-federation/modern-js';
 
+const isLocal = process.env.IS_LOCAL === 'true';
+
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({
-  dev: {
+  server: {
     port: 3051,
   },
   runtime: {
     router: true,
+  },
+  output: {
+    // Now this configuration is only used in the local when you run modern serve command.
+    // If you want to deploy the application to the platform, use your own domain name.
+    // Module federation will automatically write it to mf-manifest.json, which influences consumer to fetch remoteEntry.js.
+    assetPrefix: isLocal ? 'http://127.0.0.1:3051' : '/',
   },
   plugins: [
     appTools({

--- a/examples/module-federation/app-export/remote/module-federation.config.ts
+++ b/examples/module-federation/app-export/remote/module-federation.config.ts
@@ -2,7 +2,10 @@ import { createModuleFederationConfig } from '@module-federation/modern-js';
 
 export default createModuleFederationConfig({
   name: 'remote',
-  filename: 'remoteEntry.js',
+  manifest: {
+    filePath: 'static',
+  },
+  filename: 'static/remoteEntry.js',
   exposes: {
     './app': './src/export-App.tsx',
   },

--- a/examples/module-federation/app-export/remote/package.json
+++ b/examples/module-federation/app-export/remote/package.json
@@ -24,16 +24,16 @@
     "pre-commit": "npx lint-staged"
   },
   "dependencies": {
-    "@modern-js/runtime": "2.60.1",
-    "@module-federation/bridge-react": "^0.6.6",
-    "@module-federation/modern-js": "^0.6.6",
+    "@modern-js/runtime": "2.65.3",
+    "@module-federation/bridge-react": "0.10.0",
+    "@module-federation/modern-js": "0.10.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@modern-js/app-tools": "2.60.1",
-    "@modern-js/tsconfig": "2.60.1",
+    "@modern-js/app-tools": "2.65.3",
+    "@modern-js/tsconfig": "2.65.3",
     "@types/jest": "~29.2.4",
     "@types/node": "~16.11.7",
     "@types/react": "~18.0.26",

--- a/examples/module-federation/base/host/module-federation.config.ts
+++ b/examples/module-federation/base/host/module-federation.config.ts
@@ -3,7 +3,7 @@ import { createModuleFederationConfig } from '@module-federation/modern-js';
 export default createModuleFederationConfig({
   name: 'host',
   remotes: {
-    remote: 'remote@http://localhost:3051/mf-manifest.json',
+    remote: 'remote@http://localhost:3051/static/mf-manifest.json',
   },
   shared: {
     react: { singleton: true },

--- a/examples/module-federation/base/host/package.json
+++ b/examples/module-federation/base/host/package.json
@@ -24,15 +24,15 @@
     "pre-commit": "npx lint-staged"
   },
   "dependencies": {
-    "@modern-js/runtime": "2.60.1",
-    "@module-federation/modern-js": "^0.6.6",
+    "@modern-js/runtime": "2.65.3",
+    "@module-federation/modern-js": "0.10.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@modern-js/app-tools": "2.60.1",
-    "@modern-js/tsconfig": "2.60.1",
+    "@modern-js/app-tools": "2.65.3",
+    "@modern-js/tsconfig": "2.65.3",
     "@types/jest": "~29.2.4",
     "@types/node": "~16.11.7",
     "@types/react": "~18.0.26",

--- a/examples/module-federation/base/remote/modern.config.ts
+++ b/examples/module-federation/base/remote/modern.config.ts
@@ -1,19 +1,19 @@
 import { appTools, defineConfig } from '@modern-js/app-tools';
 import { moduleFederationPlugin } from '@module-federation/modern-js';
 
+const isLocal = process.env.IS_LOCAL === 'true';
+
 // https://modernjs.dev/en/configure/app/usage
 export default defineConfig({
-  dev: {
+  server: {
     port: 3051,
   },
   runtime: {
     router: true,
   },
-  // server: {
-  //   ssr: {
-  //     mode: 'stream',
-  //   },
-  // },
+  output: {
+    assetPrefix: isLocal ? 'http://127.0.0.1:3051' : '/',
+  },
   plugins: [
     appTools({
       bundler: 'rspack', // Set to 'webpack' to enable webpack

--- a/examples/module-federation/base/remote/modern.config.ts
+++ b/examples/module-federation/base/remote/modern.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     router: true,
   },
   output: {
+    // Now this configuration is only used in the local when you run modern serve command.
+    // If you want to deploy the application to the platform, use your own domain name.
+    // Module federation will automatically write it to mf-manifest.json, which influences consumer to fetch remoteEntry.js.
     assetPrefix: isLocal ? 'http://127.0.0.1:3051' : '/',
   },
   plugins: [

--- a/examples/module-federation/base/remote/module-federation.config.ts
+++ b/examples/module-federation/base/remote/module-federation.config.ts
@@ -2,7 +2,10 @@ import { createModuleFederationConfig } from '@module-federation/modern-js';
 
 export default createModuleFederationConfig({
   name: 'remote',
-  filename: 'remoteEntry.js',
+  manifest: {
+    filePath: 'static',
+  },
+  filename: 'static/remoteEntry.js',
   exposes: {
     './Button': './src/components/Button.tsx',
   },

--- a/examples/module-federation/base/remote/package.json
+++ b/examples/module-federation/base/remote/package.json
@@ -24,15 +24,15 @@
     "pre-commit": "npx lint-staged"
   },
   "dependencies": {
-    "@modern-js/runtime": "2.60.1",
-    "@module-federation/modern-js": "^0.6.6",
+    "@modern-js/runtime": "2.65.3",
+    "@module-federation/modern-js": "0.10.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
-    "@modern-js/app-tools": "2.60.1",
-    "@modern-js/tsconfig": "2.60.1",
+    "@modern-js/app-tools": "2.65.3",
+    "@modern-js/tsconfig": "2.65.3",
     "@types/jest": "~29.2.4",
     "@types/node": "~16.11.7",
     "@types/react": "~18.0.26",
@@ -40,6 +40,8 @@
     "lint-staged": "~13.1.0",
     "rimraf": "^6.0.1",
     "simple-git-hooks": "^2.11.1",
-    "typescript": "~5.0.4"
+    "typescript": "~5.0.4",
+    "ts-node": "~10.8.1",
+    "tsconfig-paths": "~3.14.1"
   }
 }


### PR DESCRIPTION
This PR add some logic for module-federation demo.

1. add 'static' prefix for remote module, both manifest and remoteEntry.js. Because in modern.js only serve `static/` dir in prod mode.

2. add `output.assetPrefix` for local test that run with `modern serve` command.