### PR TITLE
feat: upgrade mf plugin version

### DIFF
--- a/examples/module-federation/app-export/host/package.json
+++ b/examples/module-federation/app-export/host/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/bridge-react": "0.18.0",
-    "@module-federation/modern-js": "0.18.0",
+    "@module-federation/bridge-react": "0.18.3",
+    "@module-federation/modern-js": "0.18.3",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/examples/module-federation/app-export/remote/package.json
+++ b/examples/module-federation/app-export/remote/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/bridge-react": "0.18.0",
-    "@module-federation/modern-js": "0.18.0",
+    "@module-federation/bridge-react": "0.18.3",
+    "@module-federation/modern-js": "0.18.3",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/examples/module-federation/base/host/package.json
+++ b/examples/module-federation/base/host/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/modern-js": "0.18.0",
+    "@module-federation/modern-js": "0.18.3",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/examples/module-federation/base/remote/package.json
+++ b/examples/module-federation/base/remote/package.json
@@ -6,7 +6,7 @@
     "dev": "modern dev",
     "build": "modern build",
     "start": "modern start",
-    "serve": "modern serve",
+    "serve": "MODERN_MF_AUTO_CORS=true modern serve",
     "new": "modern new",
     "lint": "biome check",
     "lint:fix": "biome check --write",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/modern-js": "0.18.0",
+    "@module-federation/modern-js": "0.18.3",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },


### PR DESCRIPTION
Update MF plugin version to fix the issue that no cors headers in modern.js `serve` command.