### PR TITLE
chore: downgrade mf version for export app

### DIFF
--- a/examples/module-federation/app-export/host/package.json
+++ b/examples/module-federation/app-export/host/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/bridge-react": "0.18.3",
-    "@module-federation/modern-js": "0.18.3",
+    "@module-federation/bridge-react": "0.18.0",
+    "@module-federation/modern-js": "0.18.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/examples/module-federation/app-export/remote/package.json
+++ b/examples/module-federation/app-export/remote/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@modern-js/runtime": "2.68.7",
-    "@module-federation/bridge-react": "0.18.3",
-    "@module-federation/modern-js": "0.18.3",
+    "@module-federation/bridge-react": "0.18.0",
+    "@module-federation/modern-js": "0.18.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },


### PR DESCRIPTION
There is a bug in the application level module after MF Plugin 0.18.0, and it is currently being fixed. 

So downgrade the version in example until the fixed version is released.